### PR TITLE
Initialize TriOmni scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Root AGENT
+
+## Purpose
+Guidelines for contributing to the TriOmni project.
+
+## Global Rules
+- 🧪 All new functions must have a corresponding test under `/tests`.
+- 📝 Update the related README and folder-level `AGENT.md` whenever files change.
+- 🔐 Use `LockService` for any trigger-based operations.
+- 🧠 Use `globalThis.` for runtime memory and reset each run.
+- 📄 Wrap sheet reads/writes in `readDataX()` and `writeDataX()` helpers.
+- 🧰 Keep business logic separate from UI logic.
+- 🔁 Avoid circular dependencies across modules.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # TriOmni
+
+TriOmni is a modular Google Workspace add-on that helps manage Gmail and Sheets workflows.
+
+## Components
+
+1. **Omnisiah Core** – Provides a context-aware sidebar and UI when viewing Gmail or sheets.
+2. **Vox Mechana** – Shared library with classifiers, logging, and safe-write utilities.
+3. **Rite of Activation** – One-time installer that sets up triggers and config.
+
+## Installation
+
+Run the `RiteOfActivation.gs` script to install triggers and configure your environment.
+
+## Sidebar Usage
+
+When viewing Gmail or a sheet, run `showSidebar()` to open the Omnisiah sidebar. It reads account context and displays relevant tools.
+
+## Logging and Classification
+
+Emails are classified using `classifyEmailWithScore()` from the `classify/` folder. Logs are merged daily by `mergeLogs()` to keep a central history.
+
+## Folder Guide
+
+- `/core/` – Sidebar and menu logic.
+- `/lib/` – Shared helpers and classifiers.
+- `/setup/` – Installation scripts.
+- `/classify/` – Email classification pipelines.
+- `/merge/` – Log consolidation utilities.
+ - `/utils/` – Low-level helpers such as safe writes and sheet read/write wrappers.
+- `/ui/` – HTML sidebar and modal fragments.
+- `/tests/` – Unit tests for each module.
+- `/docs/` – Additional documentation.
+
+## Contributing
+
+See `AGENTS.md` files in each folder for guidance. Report bugs or suggest features by opening an issue in this repository.

--- a/classify/AGENTS.md
+++ b/classify/AGENTS.md
@@ -1,0 +1,14 @@
+# Classification Pipelines
+
+Holds Gmail classification scripts with scoring logic.
+
+## Main Export
+- `classifyEmailWithScore()` is triggered periodically with `LockService`.
+
+## Immutable Rules
+- Never bypass locks or modify log format.
+- Classifiers must use utilities from `/lib`.
+
+## When Updating
+- Add tests in `/tests/classify`.
+- Document updates in README.

--- a/classify/classify_email_with_score.gs
+++ b/classify/classify_email_with_score.gs
@@ -1,0 +1,21 @@
+/**
+ * @summary Time-driven task to classify recent emails.
+ *
+ * Example:
+ * ```
+ * classifyEmailWithScore();
+ * ```
+ */
+function classifyEmailWithScore() {
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(30000)) return;
+  // Placeholder classification logic
+  const threads = GmailApp.search('is:unread');
+  threads.forEach(t => {
+    const result = classifyText(t.getFirstMessageSubject());
+    // log result
+    if (!globalThis.logs) globalThis.logs = [];
+    globalThis.logs.push(result);
+  });
+  lock.releaseLock();
+}

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -1,0 +1,15 @@
+# Omnisiah Core Module
+
+This folder contains the sidebar and menu logic for TriOmni.
+
+## Main Export
+- `showSidebar()` is triggered from the add-on menu and loads HTML from `/ui`.
+- It reads account context via `globalThis` memory.
+
+## Immutable Rules
+- Never write logs directly; use the logging utilities in `/lib`.
+- Do not remove `LockService` usage from triggered functions.
+
+## When Updating
+- Add or update tests in `/tests/core`.
+- Update this file and the root `README.md`.

--- a/core/omnisiah_core.gs
+++ b/core/omnisiah_core.gs
@@ -1,0 +1,13 @@
+/**
+ * @summary Display the Omnisiah sidebar in Gmail or Sheets.
+ *
+ * Example:
+ * ```
+ * showSidebar();
+ * ```
+ */
+function showSidebar() {
+  const html = HtmlService.createHtmlOutputFromFile('Sidebar')
+    .setTitle('TriOmni');
+  SpreadsheetApp.getUi().showSidebar(html);
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,12 @@
+# Documentation
+
+Optional specs and visual references for TriOmni.
+
+## Main Export
+- Contains markdown or images referenced by other modules.
+
+## Immutable Rules
+- Keep docs in sync with code comments and READMEs.
+
+## When Updating
+- Update README links and maintainers.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+# Additional docs

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -1,0 +1,15 @@
+# Vox Mechana Library
+
+Shared classifiers, utilities, and logging helpers.
+
+## Main Export
+- Each file exports a single helper such as `classifyText()`.
+- Utilized by core and pipelines; relies on `globalThis.logs`.
+
+## Immutable Rules
+- Do not remove lock-protected operations.
+- Avoid writing to sheets directly; use utility wrappers.
+
+## When Updating
+- Add tests in `/tests/lib` for any new function.
+- Update related README sections.

--- a/lib/vox_mechana_lib.gs
+++ b/lib/vox_mechana_lib.gs
@@ -1,0 +1,14 @@
+/**
+ * @summary Classify a piece of text and return a score.
+ *
+ * Example:
+ * ```
+ * const result = classifyText('hello world');
+ * ```
+ * @param {string} text input text
+ * @return {Object} score and label
+ */
+function classifyText(text) {
+  if (!text) return { score: 0, label: 'unknown' };
+  return { score: 1, label: 'test' };
+}

--- a/merge/AGENTS.md
+++ b/merge/AGENTS.md
@@ -1,0 +1,13 @@
+# Log Merging Utilities
+
+Scripts to combine distributed Gmail logs into a central sheet.
+
+## Main Export
+- `mergeLogs()` runs daily under time-driven trigger with lock protection.
+
+## Immutable Rules
+- Do not remove lock usage or change sheet names.
+
+## When Updating
+- Add tests in `/tests/merge`.
+- Update README accordingly.

--- a/merge/merge_logs.gs
+++ b/merge/merge_logs.gs
@@ -1,0 +1,14 @@
+/**
+ * @summary Merge distributed logs into a central sheet.
+ *
+ * Example:
+ * ```
+ * mergeLogs();
+ * ```
+ */
+function mergeLogs() {
+  const lock = LockService.getScriptLock();
+  if (!lock.tryLock(30000)) return;
+  // Placeholder merge logic
+  lock.releaseLock();
+}

--- a/setup/AGENTS.md
+++ b/setup/AGENTS.md
@@ -1,0 +1,14 @@
+# Rite of Activation
+
+This module configures TriOmni for a user on first install.
+
+## Main Export
+- `install()` runs once and sets up triggers using `LockService`.
+
+## Immutable Rules
+- Do not change trigger names or remove locking.
+- Do not write to properties without validation.
+
+## When Updating
+- Add tests in `/tests/setup`.
+- Update documentation and this file.

--- a/setup/rite_of_activation.gs
+++ b/setup/rite_of_activation.gs
@@ -1,0 +1,16 @@
+/**
+ * @summary One-time installation for TriOmni triggers and setup.
+ *
+ * Example:
+ * ```
+ * install();
+ * ```
+ */
+function install() {
+  const lock = LockService.getScriptLock();
+  lock.waitLock(30000);
+  // Placeholder trigger creation
+  ScriptApp.newTrigger('classifyEmailWithScore')
+    .timeBased().everyHours(1).create();
+  lock.releaseLock();
+}

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,13 @@
+# Tests
+
+Mirrors project structure with unit tests for each module.
+
+## Main Export
+- Each script runs automatically via `npm test` (to be implemented).
+
+## Immutable Rules
+- Do not delete or ignore failing tests without cause.
+
+## When Updating
+- Add new tests when new functions are created.
+- Keep this folder in sync with source structure.

--- a/tests/classify/classifyEmailWithScore.test.gs
+++ b/tests/classify/classifyEmailWithScore.test.gs
@@ -1,0 +1,3 @@
+function test_classifyEmailWithScore() {
+  console.log('TODO: classification pipeline test');
+}

--- a/tests/core/showSidebar.test.gs
+++ b/tests/core/showSidebar.test.gs
@@ -1,0 +1,3 @@
+function test_showSidebar() {
+  console.log('TODO: implement showSidebar UI test');
+}

--- a/tests/lib/classifyText.test.gs
+++ b/tests/lib/classifyText.test.gs
@@ -1,0 +1,4 @@
+function test_classifyText() {
+  const res = classifyText('');
+  console.assert(res.score === 0, 'Empty text should score 0');
+}

--- a/tests/merge/mergeLogs.test.gs
+++ b/tests/merge/mergeLogs.test.gs
@@ -1,0 +1,3 @@
+function test_mergeLogs() {
+  console.log('TODO: merge logic test');
+}

--- a/tests/setup/install.test.gs
+++ b/tests/setup/install.test.gs
@@ -1,0 +1,3 @@
+function test_install() {
+  console.log('TODO: trigger creation test');
+}

--- a/tests/ui/ui.test.gs
+++ b/tests/ui/ui.test.gs
@@ -1,0 +1,3 @@
+function test_uiFiles() {
+  console.log('TODO: UI rendering test');
+}

--- a/tests/utils/safeAppendRowWithLock.test.gs
+++ b/tests/utils/safeAppendRowWithLock.test.gs
@@ -1,0 +1,3 @@
+function test_safeAppendRowWithLock() {
+  console.log('TODO: lock write test');
+}

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,13 @@
+# UI Fragments
+
+Contains HTML files rendered by the sidebar and modals.
+
+## Main Export
+- HTML fragments like `ProgressModal.html` loaded by `showSidebar()`.
+
+## Immutable Rules
+- Keep logic out of HTML; use scriptlets only for data injection.
+
+## When Updating
+- Update tests in `/tests/ui` if UI behavior changes.
+- Document changes in README.

--- a/ui/ProgressModal.html
+++ b/ui/ProgressModal.html
@@ -1,0 +1,4 @@
+<!-- @summary Progress modal for pipeline status -->
+<div id="progress-modal">
+  <p>Processing...</p>
+</div>

--- a/ui/Sidebar.html
+++ b/ui/Sidebar.html
@@ -1,0 +1,4 @@
+<!-- @summary Sidebar UI -->
+<div>
+  <h1>TriOmni Sidebar</h1>
+</div>

--- a/utils/AGENTS.md
+++ b/utils/AGENTS.md
@@ -1,0 +1,15 @@
+# Utilities
+
+Low-level helpers including lock-safe write functions.
+Provides sheet read/write wrappers.
+
+## Main Export
+- `safeAppendRowWithLock()` ensures atomic writes to shared sheets.
+- `readDataX()` and `writeDataX()` wrap sheet access operations.
+
+## Immutable Rules
+- Never remove locking or change sheet wrapper names.
+
+## When Updating
+- Add tests in `/tests/utils`.
+- Update documentation.

--- a/utils/data_helpers.gs
+++ b/utils/data_helpers.gs
@@ -1,0 +1,26 @@
+/**
+ * @summary Read data from a sheet range.
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet
+ * @param {string} rangeA1
+ * @return {Array}
+ * Example:
+ * ```
+ * const values = readDataX(sheet, 'A1:B2');
+ * ```
+ */
+function readDataX(sheet, rangeA1) {
+  return sheet.getRange(rangeA1).getValues();
+}
+
+/**
+ * @summary Write data to a sheet using appendRow.
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet
+ * @param {Array} row
+ * Example:
+ * ```
+ * writeDataX(sheet, ['a', 'b']);
+ * ```
+ */
+function writeDataX(sheet, row) {
+  sheet.appendRow(row);
+}

--- a/utils/safe_append_row_with_lock.gs
+++ b/utils/safe_append_row_with_lock.gs
@@ -1,0 +1,16 @@
+/**
+ * @summary Append a row to a sheet with script lock protection.
+ *
+ * Example:
+ * ```
+ * safeAppendRowWithLock(sheet, ['a', 'b']);
+ * ```
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet target sheet
+ * @param {Array} row row values
+ */
+function safeAppendRowWithLock(sheet, row) {
+  const lock = LockService.getScriptLock();
+  lock.waitLock(30000);
+  writeDataX(sheet, row);
+  lock.releaseLock();
+}


### PR DESCRIPTION
## Summary
- scaffold initial folder structure for TriOmni
- add core, library, setup, utils, classification, merge and ui code
- document project setup and agent guidelines
- provide placeholder HTML and Apps Script files
- add test stubs for all modules

## Testing
- `for f in tests/**/*.gs; do echo "- $f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688b1e74f18c832aa50adb04905d4908